### PR TITLE
Lägg till SPICE-exempel i boken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ och följer [semantisk versionshantering](https://semver.org/lang/sv/spec/v2.0.0
 - Ny figur för ICNIRPcalc.
 - Nya QR-koder för att lämna återkoppling på boken.
 - Nytt appendix om åskskydd.
+- Nytt appendix med exempelfiler för datorsimulering.
 
 ### Ändrat
 - Nya avsnittsnivåer i kapitel Ellära.

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,8 @@ exempelfiler/%.pdf: exempelfiler/%.cir
 	elif [ -f "$(@:.pdf=.eps)" ]; then \
 		epstopdf "$(@:.pdf=.eps)" --outfile="$@"; \
 	else \
-		echo "Ingen PostScript/EPS genererades. Lägg till 'hardcopy' i $<."; \
+		echo "Ingen PostScript/EPS genererades för $<."; \
+		echo "Lägg till ett 'hardcopy'-kommando i netlisten om du vill skapa PDF."; \
 		exit 1; \
 	fi
 

--- a/exempelfiler/.gitignore
+++ b/exempelfiler/.gitignore
@@ -1,0 +1,25 @@
+# SPICE simulation output files
+*.log
+*.raw
+*.net
+*.cir~
+*.op.raw
+
+# LTspice specific files
+*.plt
+*.fft
+*.step
+*.meas
+
+# ngspice specific files
+*.print
+*.ic
+
+# Temporary and backup files
+*~
+*.bak
+*.tmp
+
+# Operating system files
+.DS_Store
+Thumbs.db

--- a/exempelfiler/resonanskrets.cir
+++ b/exempelfiler/resonanskrets.cir
@@ -1,0 +1,24 @@
+.title KonCEPT LC-resonanskrets
+
+* Detta är en parallell LC-resonanskrets som kan användas
+* för att demonstrera resonans vid en specifik frekvens.
+
+* Strömkälla: 1 mA AC
+Iin input 0 AC 1m
+
+* Induktor: 100 uH
+L1 input 0 100u
+
+* Kondensator: 100 pF
+C1 input 0 100p
+
+* Resistor för förluster: 1 kOhm
+R1 input 0 1k
+
+* AC-analys från 100 kHz till 10 MHz med 100 punkter per dekad
+.ac dec 100 100k 10meg
+
+.save V(input)
+.plot ac V(input)
+.hardcopy
+.end

--- a/koncept.tex
+++ b/koncept.tex
@@ -154,6 +154,52 @@
 % erbjuder på egen hand.
 \usepackage{graphicx}
 
+% Paketet listings gör det möjligt att formatera källkod.
+% Används för att visa SPICE-exempel i appendix.
+\usepackage{listings}
+\lstset{
+  basicstyle=\ttfamily\small,
+  breaklines=true,
+  frame=single,
+  xleftmargin=\parindent,
+  numbers=left,
+  numberstyle=\tiny,
+  numbersep=5pt,
+  tabsize=2,
+  inputencoding=utf8,
+  extendedchars=true,
+  literate={å}{{\aa}}1 {ä}{{\"a}}1 {ö}{{\"o}}1 {Å}{{\AA}}1 {Ä}{{\"A}}1 {Ö}{{\"O}}1 {é}{{\'e}}1
+}
+
+% Definiera SPICE som språk för listings-paketet
+\lstdefinelanguage{SPICE}{
+  % Kommentarer börjar med * eller ;
+  comment=[l]{*},
+  morecomment=[l]{;},
+  % SPICE-kommandon och direktiv (case-insensitive)
+  morekeywords={.AC,.DC,.TRAN,.OP,.FOUR,.NOISE,.SENS,.TF,.DISTO,.PLOT,
+    .PRINT,.PROBE,.WIDTH,.OPTIONS,.TEMP,.IC,.NODESET,.SAVE,.LOAD,
+    .MODEL,.SUBCKT,.ENDS,.END,.INCLUDE,.LIB,.PARAM,.FUNC,.MEAS,
+    .GLOBAL,.TITLE},
+  % Känslig för stora/små bokstäver (SPICE är traditionellt case-insensitive)
+  sensitive=false,
+  % Komponentprefix (första bokstaven i komponentnamn)
+  morekeywords=[2]{R,C,L,V,I,D,Q,M,J,K,E,F,G,H,T,U,X,Y,Z,S,W},
+  % Analyskommandon
+  morekeywords=[3]{AC,DC,TRAN,OP,FOUR,NOISE,SENS,TF,DISTO},
+	% Färgsättning inspirerad av vanliga kodteman — inline RGB för tydlighet
+	commentstyle=\color[rgb]{0.35,0.35,0.35}\itshape,
+	keywordstyle=\color[rgb]{0.45,0.16,0.60},
+	keywordstyle=[2]\color[rgb]{0.12,0.27,0.65},
+	keywordstyle=[3]\color[rgb]{0.12,0.27,0.65},
+	stringstyle=\color[rgb]{0.00,0.45,0.43},
+  % Tillåt siffror och vissa specialtecken i identifierare
+  alsoletter={.,_,-},
+  % Literate för svenska tecken
+  literate=
+    {å}{{\aa}}1 {ä}{{\"a}}1 {ö}{{\"o}}1 {Å}{{\AA}}1 {Ä}{{\"A}}1 {Ö}{{\"O}}1 {é}{{\'e}}1
+}
+
 % (Beskrivning saknas.)
 \raggedbottom
 

--- a/koncept/appendix-exempelfiler.tex
+++ b/koncept/appendix-exempelfiler.tex
@@ -1,0 +1,72 @@
+\chapter{Exempelfiler}
+\label{app:exempelfiler}
+\index{GNU Radio}
+\index{SPICE}
+
+Till den här boken finns exempel- och övningsfiler som kan användas för att
+experimentera med radiosystem och elektroniska kretsar.
+
+\section{Hur man hämtar exempelfilerna}
+
+Den senaste versionen av alla exempelfiler finns i projektets GitHub-repository:
+
+\url{https://github.com/SverigesSandareamatorer/SSA-Akademin/tree/master/exempelfiler}
+
+Du kan ladda ner enskilda filer direkt från GitHub eller klona hela
+repositoryt för att få tillgång till alla exempel.
+
+\begin{center}
+\qrcode[height=3cm]{https://github.com/SverigesSandareamatorer/SSA-Akademin/tree/master/exempelfiler}
+\end{center}
+
+\section{GNU Radio-exempel}
+\index{GNU Radio}
+
+GNU Radio är en gratis programvara med öppen källkod för simulering av
+radiosystem.
+Läs mer på \url{https://www.gnuradio.org}.
+Det finns många bra exempelfiler tillgängliga på GNU Radios officiella
+webbplats och i deras dokumentation, inklusive exempel på amplitud- och
+frekvensmodulation.
+
+\section{SPICE-exempel}
+\index{SPICE}
+
+SPICE (Simulation Program with Integrated Circuit Emphasis) är en
+branschstandard för simulering av elektroniska kretsar.
+Det finns flera gratis SPICE-kompatibla program:
+
+\begin{itemize}
+\item \textbf{ngspice} -- Öppen källkod (Linux/Windows/macOS)
+\item \textbf{LTspice} -- Gratis från Analog Devices (Windows/macOS)
+\item \textbf{iCircuit} -- Mobilapp för iOS och Android
+\end{itemize}
+
+\subsection{Tillgängliga SPICE-exempel}
+
+\textbf{LC-resonanskrets:}
+\texttt{resonanskrets.cir}
+
+En parallell LC-resonanskrets som kan användas för att demonstrera
+resonans vid en specifik frekvens.
+
+\lstinputlisting[
+language=SPICE,
+caption={Källkod för LC-resonanskrets},
+label=lst:lc-resonanskrets
+]{exempelfiler/resonanskrets.cir}
+
+\mediumfig{exempelfiler/resonanskrets.png}{Kretsdiagram för LC-resonanskretsen}{fig:lc-resonanskrets}
+
+\section{Experimentera själv}
+
+Dessa exempel är en utgångspunkt för att lära sig mer om radioteknik och
+elektronik.
+Prova att
+
+\begin{itemize}
+\item ändra komponentvärden och observera hur resultatet påverkas
+\item kombinera olika kretsar för att skapa mer komplexa system
+\item mäta och jämföra simuleringsresultat med verkliga mätningar
+\item skapa egna exempel baserade på det du lärt dig i boken.
+\end{itemize}

--- a/koncept/appendix-exempelfiler.tex
+++ b/koncept/appendix-exempelfiler.tex
@@ -56,8 +56,6 @@ caption={Källkod för LC-resonanskrets},
 label=lst:lc-resonanskrets
 ]{exempelfiler/resonanskrets.cir}
 
-\mediumfig{exempelfiler/resonanskrets.png}{Kretsdiagram för LC-resonanskretsen}{fig:lc-resonanskrets}
-
 \section{Experimentera själv}
 
 Dessa exempel är en utgångspunkt för att lära sig mer om radioteknik och

--- a/koncept/inkludera-appendix.tex
+++ b/koncept/inkludera-appendix.tex
@@ -37,3 +37,6 @@
 % Appendix M
 \input{koncept/appendix-lashanvisningar}
 %
+% Appendix N
+\input{koncept/appendix-exempelfiler}
+%

--- a/koncept/kretsar--oscillatorer.tex
+++ b/koncept/kretsar--oscillatorer.tex
@@ -70,6 +70,9 @@ grundprincipen för en oscillator i stort.
 Bland annat Colpitts- och Clappkopplingarna har emellertid bättre stabilitet
 och inställbarhet i återkopplingsledet.
 
+För att experimentera med olika kretsar finns exempelfiler för datorsimulering i
+appendix~\ref{app:exempelfiler}.
+
 \subsubsection{Meissnerkoppling}
 \index{Meissnerkoppling}
 \index{oscillator!Meissnerkoppling}


### PR DESCRIPTION
- [x] Undersöka CI-felet
- [x] Ta bort referens till saknad bildfil `exempelfiler/resonanskrets.png` i appendix (fixar CI-felet)
- [x] Verifiera att CHANGELOG.md har rätt entry (redan ifylld)
- [x] Förbättra Makefile-felmeddelande för `spice-pdf`-målet